### PR TITLE
Replaced getPath with getRawPath

### DIFF
--- a/httpcache4j-api/src/main/java/org/codehaus/httpcache4j/auth/digest/RequestDigest.java
+++ b/httpcache4j-api/src/main/java/org/codehaus/httpcache4j/auth/digest/RequestDigest.java
@@ -161,7 +161,7 @@ public class RequestDigest {
     }
 
     public static RequestDigest newInstance(UsernamePasswordChallenge challenge, HTTPRequest request, Digest digest) {
-        return new RequestDigest(challenge, request.getMethod(), URI.create(request.getRequestURI().getPath()), digest);
+        return new RequestDigest(challenge, request.getMethod(), URI.create(request.getRequestURI().getRawPath()), digest);
     }
 
     private void addDirective(String name, String value, boolean quoted) {


### PR DESCRIPTION
getPath returns a decoded string and URI.create will fail if the path contains any chars which needs encoding. Replaced with getRawPath to fix.
