### PR TITLE
Avoid "org.apache.http.ProtocolException: Content-Length header already present" exception

### DIFF
--- a/resolvers/resolvers-httpcomponents-httpclient/src/main/java/org/codehaus/httpcache4j/resolver/HTTPClientResponseResolver.java
+++ b/resolvers/resolvers-httpcomponents-httpclient/src/main/java/org/codehaus/httpcache4j/resolver/HTTPClientResponseResolver.java
@@ -33,6 +33,7 @@ import org.codehaus.httpcache4j.auth.*;
 import org.codehaus.httpcache4j.payload.DelegatingInputStream;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.*;
+import org.apache.http.protocol.HTTP;
 import org.apache.http.*;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.DefaultHttpClient;


### PR DESCRIPTION
If a request already has the Content-Length set, and you use setEntity, it seems like RequestContent.process kicks in and wants to set these headers too, casting an exception. 
