### PR TITLE
Improvement on the previous pull request

### DIFF
--- a/resolvers/resolvers-httpcomponents-httpclient/src/main/java/org/codehaus/httpcache4j/resolver/HTTPClientResponseResolver.java
+++ b/resolvers/resolvers-httpcomponents-httpclient/src/main/java/org/codehaus/httpcache4j/resolver/HTTPClientResponseResolver.java
@@ -25,6 +25,7 @@ import org.apache.http.impl.conn.PoolingClientConnectionManager;
 import org.apache.http.impl.conn.SchemeRegistryFactory;
 import org.apache.http.params.*;
 import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.RequestContent;
 import org.apache.http.util.EntityUtils;
 import org.codehaus.httpcache4j.*;
 import org.codehaus.httpcache4j.Header;
@@ -97,6 +98,11 @@ public class HTTPClientResponseResolver extends AbstractResponseResolver {
             }
 
         }
+        if (httpClient instanceof DefaultHttpClient) {
+            DefaultHttpClient client = (DefaultHttpClient) httpClient;
+            client.removeRequestInterceptorByClass(RequestContent.class);
+            client.addRequestInterceptor(new RequestContent(true));
+        }
         HttpClientParams.setAuthenticating(params, false);
         if (proxyHost != null) {
             HttpHost host = new HttpHost(proxyHost.getHost(), proxyHost.getPort(), proxyHost.getScheme());
@@ -160,8 +166,6 @@ public class HTTPClientResponseResolver extends AbstractResponseResolver {
         if (request.hasPayload() && realRequest instanceof HttpEntityEnclosingRequest) {
             HttpEntityEnclosingRequest req = (HttpEntityEnclosingRequest) realRequest;
             req.setEntity(new PayloadEntity(request.getPayload(), getConfiguration().isUseChunked()));
-            req.removeHeaders(HTTP.CONTENT_LEN);
-            req.removeHeaders(HTTP.TRANSFER_ENCODING);
         }
         return realRequest;
     }


### PR DESCRIPTION
Previous fix for "org.apache.http.ProtocolException: Content-Length header already present" only avoided cases where the problem was caused from within httpcache4j. There are cases where the Content-Length header is set before arriving here. Setting the overwrite flag of the RequestContent interceptor handles this situation as well. 
