### PR TITLE
Upgrade to Guava 16.0.1

### DIFF
--- a/httpcache4j-api/src/main/java/org/codehaus/httpcache4j/payload/ByteArrayPayload.java
+++ b/httpcache4j-api/src/main/java/org/codehaus/httpcache4j/payload/ByteArrayPayload.java
@@ -16,8 +16,8 @@
 package org.codehaus.httpcache4j.payload;
 
 import com.google.common.io.ByteStreams;
-import com.google.common.io.Closeables;
 import org.codehaus.httpcache4j.MIMEType;
+import org.codehaus.httpcache4j.util.IOUtils;
 
 import java.io.Serializable;
 import java.io.InputStream;
@@ -38,7 +38,7 @@ public class ByteArrayPayload implements Payload, Serializable {
         try {
             this.bytes = ByteStreams.toByteArray(stream);
         } finally {
-            Closeables.closeQuietly(stream);
+            IOUtils.closeQuietly(stream);
         }
         length = bytes.length;
         this.type = type;

--- a/httpcache4j-api/src/main/java/org/codehaus/httpcache4j/payload/MD5CaculcatingPayload.java
+++ b/httpcache4j-api/src/main/java/org/codehaus/httpcache4j/payload/MD5CaculcatingPayload.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.DigestInputStream;
 
+import com.google.common.io.ByteSource;
 import com.google.common.io.FileBackedOutputStream;
-import com.google.common.io.InputSupplier;
 import org.codehaus.httpcache4j.HTTPException;
 import org.codehaus.httpcache4j.MIMEType;
 import org.codehaus.httpcache4j.util.Digester;
@@ -23,7 +23,7 @@ public class MD5CaculcatingPayload implements Payload {
     private final MIMEType mimeType;
     private final long length;
     private final String md5;
-    private final InputSupplier<InputStream> supplier;
+    private final ByteSource byteSource;
 
     private MD5CaculcatingPayload(final InputStream stream, MIMEType mimeType, long length) {
         this.mimeType = mimeType;
@@ -36,7 +36,7 @@ public class MD5CaculcatingPayload implements Payload {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        supplier = os.getSupplier();
+        byteSource = os.asByteSource();
     }
 
     public String getMD5() {
@@ -49,7 +49,7 @@ public class MD5CaculcatingPayload implements Payload {
 
     public InputStream getInputStream() {
         try {
-            return supplier.getInput();
+            return byteSource.openStream();
         } catch (IOException e) {
             throw new HTTPException(e);
         }

--- a/httpcache4j-api/src/main/java/org/codehaus/httpcache4j/util/PropertiesLoader.java
+++ b/httpcache4j-api/src/main/java/org/codehaus/httpcache4j/util/PropertiesLoader.java
@@ -1,7 +1,5 @@
 package org.codehaus.httpcache4j.util;
 
-import com.google.common.io.Closeables;
-
 import java.io.*;
 import java.util.Properties;
 
@@ -17,7 +15,7 @@ public final class PropertiesLoader {
             throw new RuntimeException(e);
         }
         finally {
-            Closeables.closeQuietly(reader);
+            IOUtils.closeQuietly(reader);
         }
         return properties;
     }
@@ -30,7 +28,7 @@ public final class PropertiesLoader {
             throw new RuntimeException(e);
         }
         finally {
-            Closeables.closeQuietly(stream);
+            IOUtils.closeQuietly(stream);
         }
         return properties;
     }

--- a/httpcache4j-storage-api/src/test/java/org/codehaus/httpcache4j/cache/ConcurrentCacheStorageAbstractTest.java
+++ b/httpcache4j-storage-api/src/test/java/org/codehaus/httpcache4j/cache/ConcurrentCacheStorageAbstractTest.java
@@ -16,9 +16,9 @@
 package org.codehaus.httpcache4j.cache;
 
 import com.google.common.io.CharStreams;
-import com.google.common.io.Closeables;
 import org.codehaus.httpcache4j.*;
 import org.codehaus.httpcache4j.payload.InputStreamPayload;
+import org.codehaus.httpcache4j.util.IOUtils;
 import org.codehaus.httpcache4j.util.NullInputStream;
 import org.junit.After;
 import static org.junit.Assert.*;
@@ -128,7 +128,7 @@ public abstract class ConcurrentCacheStorageAbstractTest {
             fail("unable to create string from stream");
         }
         finally {
-            Closeables.closeQuietly(is);
+            IOUtils.closeQuietly(is);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>15.0</version>
+        <version>16.0.1</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/storage/storage-file/src/main/java/org/codehaus/httpcache4j/cache/PersistentCacheStorage.java
+++ b/storage/storage-file/src/main/java/org/codehaus/httpcache4j/cache/PersistentCacheStorage.java
@@ -20,10 +20,10 @@ import java.io.*;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.io.Closeables;
 import org.codehaus.httpcache4j.HTTPResponse;
 import org.codehaus.httpcache4j.payload.FilePayload;
 import org.codehaus.httpcache4j.payload.Payload;
+import org.codehaus.httpcache4j.util.IOUtils;
 import org.codehaus.httpcache4j.util.MemoryCache;
 import org.codehaus.httpcache4j.util.SerializationUtils;
 
@@ -124,7 +124,7 @@ public class PersistentCacheStorage extends MemoryCacheStorage implements Serial
                     cache = new MemoryCache(capacity);
                 }
                 finally {
-                    Closeables.closeQuietly(inputStream);
+                    IOUtils.closeQuietly(inputStream);
                 }
             }
             else {
@@ -148,7 +148,7 @@ public class PersistentCacheStorage extends MemoryCacheStorage implements Serial
             //Ignored, we create a new one.
         }
         finally {
-            Closeables.closeQuietly(outputStream);
+            IOUtils.closeQuietly(outputStream);
             read.unlock();
         }
     }


### PR DESCRIPTION
Guava < 16.0.1 has issues with jdk 1.7.0_51-b51. See https://code.google.com/p/guava-libraries/issues/detail?id=1635 

People should really not run older Guava versions on the new jdk and httpcache4j uses previously deprecated Guava methods which have been removed from Guava 16, making it impossible to use httpcache4j and Guava 16.

This pull request upgrades httpcache4j to Guava 16.0.1 and removes usage of deprecated classes/methods in Guava.
