### PR TITLE
set the socket timeout on the requestconfig as well as the socketconfig....

### DIFF
--- a/httpcache4j-core/src/main/java/org/codehaus/httpcache4j/cache/MemoryCacheStorage.java
+++ b/httpcache4j-core/src/main/java/org/codehaus/httpcache4j/cache/MemoryCacheStorage.java
@@ -76,11 +76,11 @@ public class MemoryCacheStorage implements CacheStorage {
 
 
     public final HTTPResponse insert(final HTTPRequest request, final HTTPResponse response) {
-        write.lock();
         Key key = Key.create(request, response);
+        HTTPResponse cacheableResponse = rewriteResponse(key, response);
+        write.lock();
         try {
             invalidate(key);
-            HTTPResponse cacheableResponse = rewriteResponse(key, response);
             return putImpl(key, cacheableResponse);
         } finally {
             write.unlock();

--- a/resolvers/resolvers-httpcomponents-httpclient/src/main/java/org/codehaus/httpcache4j/resolver/HttpClientFactory.java
+++ b/resolvers/resolvers-httpcomponents-httpclient/src/main/java/org/codehaus/httpcache4j/resolver/HttpClientFactory.java
@@ -81,6 +81,9 @@ public class HttpClientFactory {
         if (config.getConnectionRequestTimeout().isPresent()) {
             requestConfig.setConnectionRequestTimeout(config.getConnectionRequestTimeout().get());
         }
+        if (config.getSocketTimeout().isPresent()){
+            requestConfig.setSocketTimeout(config.getSocketTimeout().get());
+        }
         requestConfig.setAuthenticationEnabled(false);
         requestConfig.setStaleConnectionCheckEnabled(false);
         if (proxyHost != null) {


### PR DESCRIPTION
- set the socket timeout on the requestconfig as well as the socketconfig
- put stream operation outside lock

Background: We had a case where our app would freeze totally one a single node. stack dumps showed most threads were stuck waiting on the reentrant lock in MemoryCacheStorage. The one running thread holding the lock was stuck on java.net.SocketInputStream.socketRead0(Native Method) for several hours (from abt 22:00 -> 06:00, where a manual restart was done). 

So it seems that 
a) the socket timeout was not respected (we had set it to 60s). 
b) doing stream operaions inside the reentrant lock (single point of entry) 
together caused a deadlock. 

Trying a fix here, but not sure if its the best one. A potential problem with this is that a fast request to resource /x could potentially be overwritten in cache by a stale resource by a slow request to /x. Mostly a theoretical issue i think.. 