### PR TITLE
Stream op lock issue

### DIFF
--- a/httpcache4j-core/src/main/java/org/codehaus/httpcache4j/cache/MemoryCacheStorage.java
+++ b/httpcache4j-core/src/main/java/org/codehaus/httpcache4j/cache/MemoryCacheStorage.java
@@ -74,13 +74,12 @@ public class MemoryCacheStorage implements CacheStorage {
         throw new IllegalArgumentException("Unable to cache response");
     }
 
-
     public final HTTPResponse insert(final HTTPRequest request, final HTTPResponse response) {
-        write.lock();
         Key key = Key.create(request, response);
+        HTTPResponse cacheableResponse = rewriteResponse(key, response);
+        write.lock();
         try {
             invalidate(key);
-            HTTPResponse cacheableResponse = rewriteResponse(key, response);
             return putImpl(key, cacheableResponse);
         } finally {
             write.unlock();

--- a/httpcache4j-storage-api/src/main/java/org/codehaus/httpcache4j/cache/FileManager.java
+++ b/httpcache4j-storage-api/src/main/java/org/codehaus/httpcache4j/cache/FileManager.java
@@ -15,16 +15,18 @@
 
 package org.codehaus.httpcache4j.cache;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.net.URI;
+
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import org.codehaus.httpcache4j.util.DeletingFileFilter;
 import org.codehaus.httpcache4j.util.Digester;
 import org.codehaus.httpcache4j.util.IOUtils;
-
-import java.io.*;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 
 /**
  * @author <a href="mailto:hamnis@codehaus.org">Erlend Hamnaberg</a>
@@ -71,7 +73,7 @@ public final class FileManager implements Serializable {
         if (!toFile.getParentFile().exists()) {
             ensureDirectoryExists(toFile.getParentFile());
         }
-        Files.move(fromFile.toPath(), toFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        fromFile.renameTo(toFile);
         if (toFile.length() == 0) {
             toFile.delete();
             toFile = null;

--- a/httpcache4j-storage-api/src/main/java/org/codehaus/httpcache4j/cache/FileManager.java
+++ b/httpcache4j-storage-api/src/main/java/org/codehaus/httpcache4j/cache/FileManager.java
@@ -23,6 +23,8 @@ import org.codehaus.httpcache4j.util.IOUtils;
 
 import java.io.*;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 /**
  * @author <a href="mailto:hamnis@codehaus.org">Erlend Hamnaberg</a>
@@ -62,6 +64,23 @@ public final class FileManager implements Serializable {
         }
 
         return file;
+    }
+
+    public synchronized File moveFile(File fromFile, Key to) throws IOException {
+        File toFile = resolve(to);
+        if (!toFile.getParentFile().exists()) {
+            ensureDirectoryExists(toFile.getParentFile());
+        }
+        Files.move(fromFile.toPath(), toFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        if (toFile.length() == 0) {
+            toFile.delete();
+            toFile = null;
+        }
+        if (toFile != null && !toFile.exists()) {
+            throw new IOException(String.format("Failed to move File '%s' to File %s for Key: %s", fromFile.getName(), toFile.getName(), to));
+        }
+
+        return toFile;
     }
 
     public synchronized void clear() {

--- a/storage/storage-file/src/main/java/org/codehaus/httpcache4j/cache/PersistentCacheStorage.java
+++ b/storage/storage-file/src/main/java/org/codehaus/httpcache4j/cache/PersistentCacheStorage.java
@@ -16,13 +16,20 @@
 
 package org.codehaus.httpcache4j.cache;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.Random;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.codehaus.httpcache4j.HTTPResponse;
 import org.codehaus.httpcache4j.payload.FilePayload;
 import org.codehaus.httpcache4j.payload.Payload;
+import org.codehaus.httpcache4j.uri.URIBuilder;
 import org.codehaus.httpcache4j.util.IOUtils;
 import org.codehaus.httpcache4j.util.MemoryCache;
 import org.codehaus.httpcache4j.util.SerializationUtils;
@@ -87,6 +94,13 @@ public class PersistentCacheStorage extends MemoryCacheStorage implements Serial
     @Override
     protected HTTPResponse putImpl(Key key, HTTPResponse response) {
         HTTPResponse res = super.putImpl(key, response);
+        if (response.hasPayload() && response.getPayload() instanceof FilePayload) {
+            final FilePayload payload = (FilePayload)response.getPayload();
+            try {
+                res = res.withPayload(createRealPayload(key, payload));
+            } catch (IOException ignore) {
+            }
+        }
         if (serializationPolicy.shouldWePersist(modCount++, lastSerialization)) {
             lastSerialization = System.currentTimeMillis();
             saveCacheToDisk();
@@ -101,7 +115,19 @@ public class PersistentCacheStorage extends MemoryCacheStorage implements Serial
 
     @Override
     protected Payload createPayload(Key key, Payload payload, InputStream stream) throws IOException {
-        File file = fileManager.createFile(key, stream);
+        File file = fileManager.createFile(tmpKey(key), stream);
+        if (file != null && file.exists()) {
+            return new FilePayload(file, payload.getMimeType());
+        }
+        return null;
+    }
+
+    private Key tmpKey(Key key) {
+        return new Key(URIBuilder.fromURI(key.getURI()).addPath((new Random()).nextInt()+"_httpCache4jTmp").toURI(), key.getVary());
+    }
+
+    private Payload createRealPayload(Key key, FilePayload payload) throws IOException {
+        File file = fileManager.moveFile(payload.getFile(), key);
         if (file != null && file.exists()) {
             return new FilePayload(file, payload.getMimeType());
         }


### PR DESCRIPTION
Move stream IO operations out of the lock.
File operations now first write to a tmp file, then do a Files.move inside the lock.

ref: https://github.com/httpcache4j/httpcache4j/pull/35

How about something like this?
