### PR TITLE
Added docstring mentioning explicit guava dependency.

### DIFF
--- a/storage/storage-file/src/main/java/org/codehaus/httpcache4j/cache/IndexedPersistentCacheStorage.java
+++ b/storage/storage-file/src/main/java/org/codehaus/httpcache4j/cache/IndexedPersistentCacheStorage.java
@@ -15,6 +15,11 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
+ * <p>...some description here...</p>
+ *
+ * <p>Note: you must explicitly add google guava as a dependency to
+ * be able to use this CacheStorage implementation.</p>
+ *
  * @author <a href="mailto:hamnis@codehaus.org">Erlend Hamnaberg</a>
  */
 @Beta


### PR DESCRIPTION
Would be great to know why there are multiple file-based cache storage implementations. Could you extend this PR to add descriptions to the docstring?