### PR TITLE
 Fix: Null check before closing input stream

### DIFF
--- a/httpcache4j-api/src/main/java/org/codehaus/httpcache4j/HTTPResponse.java
+++ b/httpcache4j-api/src/main/java/org/codehaus/httpcache4j/HTTPResponse.java
@@ -120,7 +120,9 @@ public final class HTTPResponse {
     public void consume() {
         payload.ifPresent(p -> {
             try(InputStream is = p.getInputStream()) {
-                is.close();
+                if (null != is) {
+                    is.close();
+                }
             } catch (IOException ignored){}
         });
     }


### PR DESCRIPTION
The problem occurs when using the InputStreamPayload and the stream are already close when calling HTTPResponse.consume()