### PR TITLE
Correct isCacheable logic

### DIFF
--- a/httpcache4j-core/src/main/java/org/codehaus/httpcache4j/cache/HTTPCacheHelper.java
+++ b/httpcache4j-core/src/main/java/org/codehaus/httpcache4j/cache/HTTPCacheHelper.java
@@ -129,7 +129,7 @@ class HTTPCacheHelper {
     boolean isCacheableRequest(HTTPRequest request) {
         if (request.getMethod().isCacheable()) {
             Optional<CacheControl> cc = request.getCacheControl();
-            return OptionalUtils.forall(cc, c -> c.isNoCache() || !c.isNoStore());
+            return OptionalUtils.forall(cc, c -> !c.isNoCache() || !c.isNoStore());
         }
         return false;
     }


### PR DESCRIPTION
The current logic seems to be broken since 4e75e081f4502ca798097f3ba521e129e5798fc3

`return !cc.isNoCache() || !cc.isNoStore();`
got replaced with 
`return cc.forall(c -> c.isNoCache() || !c.isNoStore());`
(flipped isNoCache boolean)