### PR TITLE
Fixed Issue #56

### DIFF
--- a/httpcache4j-storage-api/src/main/java/org/codehaus/httpcache4j/cache/SerializableCacheItem.java
+++ b/httpcache4j-storage-api/src/main/java/org/codehaus/httpcache4j/cache/SerializableCacheItem.java
@@ -76,7 +76,7 @@ public class SerializableCacheItem implements Serializable, CacheItem {
         Headers headers = Headers.parse(object.getProperty("headers"));
         Optional<Payload> p = Optional.empty();
         if (object.containsKey("file")) {
-            p = Optional.of(new FilePayload(new File(object.getProperty("file")), headers.getContentType().get()));
+            p = Optional.of(new FilePayload(new File(object.getProperty("file")), headers.getContentType().orElse(MIMEType.APPLICATION_OCTET_STREAM)));
         }
         return new DefaultCacheItem(new HTTPResponse(p, status, headers), time.get());
     }


### PR DESCRIPTION
If no content type is present use MIMEType.APPLICATION_OCTET_STREAM instead of throwing java.util.NoSuchElementException: No value present